### PR TITLE
Enhancement | Hide cancelled orders.

### DIFF
--- a/app/features/orders/hooks/useOrders.ts
+++ b/app/features/orders/hooks/useOrders.ts
@@ -31,7 +31,7 @@ export const useOrders = () => {
           today.setHours(0, 0, 0, 0);
 
           // Only show orders with the following statuses. Different from deliveryStatus.
-          const statusesToShow = ['pending', 'confirmed', 'delivered'];
+          const statusesToShow = ['pending', 'confirmed'];
 
           // Only include orders for today and the future.
           return order.date >= today && statusesToShow.includes(order.status);

--- a/app/features/orders/hooks/useOrders.ts
+++ b/app/features/orders/hooks/useOrders.ts
@@ -30,8 +30,11 @@ export const useOrders = () => {
           const today = new Date();
           today.setHours(0, 0, 0, 0);
 
+          // Only show orders with the following statuses. Different from deliveryStatus.
+          const statusesToShow = ['pending', 'confirmed', 'delivered'];
+
           // Only include orders for today and the future.
-          return order.date >= today;
+          return order.date >= today && statusesToShow.includes(order.status);
         })
         // Sort the orders by date.
         .sort((a, b) => a.date.getTime() - b.date.getTime()),

--- a/app/features/orders/transformers/orderTransformer.ts
+++ b/app/features/orders/transformers/orderTransformer.ts
@@ -46,6 +46,7 @@ export const orderTransformer = (order: OrdersResponse['orders'][number]) => {
 
   return {
     id: order._id,
+    status: order.status,
     date,
     displayDay,
     displayDayName,


### PR DESCRIPTION
# 📝 Description

This PR aims to enhance the extension by hiding orders that are not of a relevant status (i.e. cancelled). Sometimes due to reasons like change of decision or payment issue, my order status will be set to cancelled but it still shows up on the orders page. This PR filters those orders out. 

*Status and deliveryStatus are different, this PR doesn't concern deliveryStatus.* 

Before:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/b792d306-8554-4c9e-b707-b4b6bc8c9f3a">

After:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/1c1e3215-42b6-4421-909e-785a1839200e">


# 📝 Context

Context and/or changes about the ticket:

1. Updated the orderTransformer to include order status.
2. Updated the useOrders hook to filter out order statuses not necessary to see (i.e. cancelled).

# ✌️ Checklist

- [X] Built the application and passed the unit tests locally
- [X] Ran the application locally
- [X] Tested the relevant change(s). You may mention the test data and test steps used. You may also mention the reason if it is not tested.
